### PR TITLE
[Feat] Keyword 관련 파일 생성 및 chatGPT 주제 생성 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 **/src/main/resources/application-db.properties
+**/src/main/resources/application.yml
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,42 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.13'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.13'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 }
 
 group = 'com.golab'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.springframework.session:spring-session-core'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.session:spring-session-core'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'io.github.flashvayne:chatgpt-spring-boot-starter:1.0.4'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/golab/talk/controller/ChatGPTtest.java
+++ b/src/main/java/com/golab/talk/controller/ChatGPTtest.java
@@ -1,0 +1,28 @@
+package com.golab.talk.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.golab.talk.service.ChatService;
+
+import io.github.flashvayne.chatgpt.service.ChatgptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+@RequestMapping("/chatGPT")
+public class ChatGPTtest {
+	private final ChatgptService chatgptService;
+	private final ChatService chatService;
+
+	@PostMapping("/test")
+	public String test(@RequestBody String question) {
+		return chatService.getChatResponse(question);
+		//\n\nAs an AI language model, I don't have feelings, but I'm functioning well. Thank you for asking. How can I assist you today?
+	}
+
+}

--- a/src/main/java/com/golab/talk/controller/ChatGPTtest.java
+++ b/src/main/java/com/golab/talk/controller/ChatGPTtest.java
@@ -1,11 +1,19 @@
 package com.golab.talk.controller;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.golab.talk.service.ChatService;
+import com.golab.talk.service.KeywordService;
 
 import io.github.flashvayne.chatgpt.service.ChatgptService;
 import lombok.RequiredArgsConstructor;
@@ -19,10 +27,30 @@ public class ChatGPTtest {
 	private final ChatgptService chatgptService;
 	private final ChatService chatService;
 
+	@Autowired
+	private KeywordService keywordService;
+
+	//question을 받아서 질문 리스트를 return
 	@PostMapping("/test")
 	public String test(@RequestBody String question) {
 		return chatService.getChatResponse(question);
-		//\n\nAs an AI language model, I don't have feelings, but I'm functioning well. Thank you for asking. How can I assist you today?
+	}
+
+	//@Scheduled(cron = "0 50 23 * * *") //매일 23시 50분에 실행
+	@GetMapping("/keyword")
+	public ResponseEntity<List<String>> getTodayTopic() {
+		System.out.println("오늘의 키워드를 생성합니다." + LocalDateTime.now());
+		log.info("오늘의 키워드를 생성합니다." + LocalDateTime.now());
+
+		List<String> list = keywordService.findAllKeyword();
+
+		for (String keyword : list) {
+			String question = "우리가 대한민국 10대들을 대상으로 1~3분 정도 되는 토론 게임을 하려고 해. 그 때 \""
+				+ keyword + "\"에 대한 짧은 주제를 10가지 제시해줘. 그리고 다른 말은 하지 말고 주제만 번호를 달아서 알려줘";
+			String result = chatService.getChatResponse(question);
+			
+		}
+		return new ResponseEntity<>(list, HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/com/golab/talk/controller/GameRoomController.java
+++ b/src/main/java/com/golab/talk/controller/GameRoomController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/golab/talk/controller/KeywordController.java
+++ b/src/main/java/com/golab/talk/controller/KeywordController.java
@@ -1,0 +1,4 @@
+package com.golab.talk.controller;
+
+public class KeywordController {
+}

--- a/src/main/java/com/golab/talk/controller/Scheduler.java
+++ b/src/main/java/com/golab/talk/controller/Scheduler.java
@@ -1,6 +1,7 @@
 package com.golab.talk.controller;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import javax.transaction.Transactional;
 
@@ -9,10 +10,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.golab.talk.service.GameRoomService;
+import com.golab.talk.service.KeywordService;
 
 import lombok.extern.java.Log;
 
@@ -23,6 +26,9 @@ public class Scheduler {
 
 	@Autowired
 	private GameRoomService gameRoomService;
+
+	@Autowired
+	private KeywordService keywordService;
 
 	@Scheduled(cron = "0 50 23 * * *") //매일 23시 50분에 실행
 	@Transactional(rollbackOn = Exception.class)
@@ -38,6 +44,17 @@ public class Scheduler {
 		} else {
 			return new ResponseEntity<>("게임방 목록 초기화를 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	//@Scheduled(cron = "0 50 23 * * *") //매일 23시 50분에 실행
+	@GetMapping("/keyword")
+	public ResponseEntity<List<String>> getTodayTopic() {
+		System.out.println("오늘의 키워드를 생성합니다." + LocalDateTime.now());
+		log.info("오늘의 키워드를 생성합니다." + LocalDateTime.now());
+
+		List<String> list = keywordService.findAllKeyword();
+
+		return new ResponseEntity<>(list, HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/com/golab/talk/controller/Scheduler.java
+++ b/src/main/java/com/golab/talk/controller/Scheduler.java
@@ -54,6 +54,10 @@ public class Scheduler {
 
 		List<String> list = keywordService.findAllKeyword();
 
+		for (String keyword : list) {
+			String question = "우리가 대한민국 10대들을 대상으로 1~3분 정도 되는 토론 게임을 하려고 해. 그 때 \""
+				+ keyword + "\"에 대한 짧은 주제를 10가지 제시해줘.";
+		}
 		return new ResponseEntity<>(list, HttpStatus.OK);
 	}
 

--- a/src/main/java/com/golab/talk/controller/Scheduler.java
+++ b/src/main/java/com/golab/talk/controller/Scheduler.java
@@ -25,7 +25,7 @@ public class Scheduler {
 	private GameRoomService gameRoomService;
 
 	@Scheduled(cron = "0 50 23 * * *") //매일 23시 50분에 실행
-	@Transactional
+	@Transactional(rollbackOn = Exception.class)
 	@DeleteMapping("/gameRoom")
 	public ResponseEntity<String> deleteGameRoom() {
 		System.out.println("GameRoom을 reset합니다." + LocalDateTime.now());

--- a/src/main/java/com/golab/talk/dto/KeywordDto.java
+++ b/src/main/java/com/golab/talk/dto/KeywordDto.java
@@ -1,0 +1,17 @@
+package com.golab.talk.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class KeywordDto {
+
+	private int keyId;
+	private String keyName;
+
+}

--- a/src/main/java/com/golab/talk/repository/KeywordRepository.java
+++ b/src/main/java/com/golab/talk/repository/KeywordRepository.java
@@ -1,0 +1,18 @@
+package com.golab.talk.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.golab.talk.domain.Keyword;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+	//모든 키워드 조회
+	@Query(value = "SELECT key_name FROM keyword", nativeQuery = true)
+	List<String> findAllKeyword();
+
+}

--- a/src/main/java/com/golab/talk/service/ChatService.java
+++ b/src/main/java/com/golab/talk/service/ChatService.java
@@ -1,0 +1,5 @@
+package com.golab.talk.service;
+
+public interface ChatService {
+	String getChatResponse(String message);
+}

--- a/src/main/java/com/golab/talk/service/KeywordService.java
+++ b/src/main/java/com/golab/talk/service/KeywordService.java
@@ -1,0 +1,10 @@
+package com.golab.talk.service;
+
+import java.util.List;
+
+public interface KeywordService {
+
+	//모든 키워드 조회
+	List<String> findAllKeyword();
+
+}

--- a/src/main/java/com/golab/talk/service/impl/ChatServiceImpl.java
+++ b/src/main/java/com/golab/talk/service/impl/ChatServiceImpl.java
@@ -1,0 +1,20 @@
+package com.golab.talk.service.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.golab.talk.service.ChatService;
+
+import io.github.flashvayne.chatgpt.service.ChatgptService;
+
+@Service
+public class ChatServiceImpl implements ChatService {
+
+	@Autowired
+	private ChatgptService chatgptService;
+
+	@Override
+	public String getChatResponse(String message) {
+		return chatgptService.sendMessage(message);
+	}
+}

--- a/src/main/java/com/golab/talk/service/impl/KeywordServiceImpl.java
+++ b/src/main/java/com/golab/talk/service/impl/KeywordServiceImpl.java
@@ -1,0 +1,24 @@
+package com.golab.talk.service.impl;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.golab.talk.repository.KeywordRepository;
+import com.golab.talk.service.KeywordService;
+
+@Service
+public class KeywordServiceImpl implements KeywordService {
+
+	@Autowired
+	private KeywordRepository keywordRepository;
+
+	@Override
+	public List<String> findAllKeyword() {
+		List<String> list;
+		list = keywordRepository.findAllKeyword();
+		return list;
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+chatgpt:
+  api-key: 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


### PR DESCRIPTION
## 📌 관련 이슈
Feat: 토론 게임 관련 기능 구현 #10

## ✨ 과제 내용
 ChatGPTtest, KeywordController, KeywordDto, KeywordRepository, ChatService, KeywordService, ChatServiceImpl, KeywordServiceImpl, application.yml추가 
build, Scheduler 수정

- chatGPT API 적용
- 키워드 전송 후 주제 10가지 return 받는 것 까지 구현

## 📸 스크린샷
![image](https://github.com/GoLAB-Project/GoLAB-backend/assets/99467446/43f94d1b-c83f-4650-b3a3-32601def1439)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
application 삭제 예정
